### PR TITLE
feat: add zone creation flow through devices store

### DIFF
--- a/devices/components/add-zone-dialog/add-zone-dialog.component.html
+++ b/devices/components/add-zone-dialog/add-zone-dialog.component.html
@@ -1,0 +1,43 @@
+<div class="add-zone-dialog">
+  <h2>Añadir zona</h2>
+  <form [formGroup]="zoneForm" (ngSubmit)="submit()">
+    <div class="form-field">
+      <label for="zoneName">Nombre del área</label>
+      <input id="zoneName" type="text" pInputText formControlName="name" />
+      <small class="error" *ngIf="zoneForm.controls.name.invalid && zoneForm.controls.name.touched">
+        El nombre es obligatorio y debe tener al menos 3 caracteres.
+      </small>
+    </div>
+
+    <div class="form-field">
+      <label for="zoneType">Tipo de área</label>
+      <select id="zoneType" formControlName="zoneType">
+        <option value="" disabled>Selecciona un tipo</option>
+        <option *ngFor="let type of zoneTypes" [ngValue]="type.value">{{ type.label }}</option>
+      </select>
+      <small class="error" *ngIf="zoneForm.controls.zoneType.invalid && zoneForm.controls.zoneType.touched">
+        Debes seleccionar un tipo de área.
+      </small>
+    </div>
+
+    <div class="form-field">
+      <label for="location">Ubicación</label>
+      <select id="location" formControlName="locationId">
+        <option value="" disabled>Selecciona una ubicación</option>
+        <option *ngFor="let location of locationOptions" [ngValue]="location.id">
+          {{ location.name }}
+        </option>
+      </select>
+      <small class="error" *ngIf="zoneForm.controls.locationId.invalid && zoneForm.controls.locationId.touched">
+        Debes seleccionar una ubicación válida.
+      </small>
+    </div>
+
+    <div class="actions">
+      <button type="button" class="btn btn-secondary" (click)="cancel()">Cancelar</button>
+      <button type="submit" class="btn btn-primary" [disabled]="zoneForm.invalid || isSubmitting">
+        {{ isSubmitting ? 'Guardando…' : 'Aceptar' }}
+      </button>
+    </div>
+  </form>
+</div>

--- a/devices/components/add-zone-dialog/add-zone-dialog.component.scss
+++ b/devices/components/add-zone-dialog/add-zone-dialog.component.scss
@@ -1,0 +1,44 @@
+.add-zone-dialog {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  width: 100%;
+  max-width: 420px;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.form-field label {
+  font-weight: 600;
+}
+
+.form-field select,
+.form-field input {
+  padding: 0.5rem;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+}
+
+.error {
+  color: #d14343;
+  font-size: 0.8rem;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+}
+
+.actions .btn {
+  min-width: 120px;
+}
+
+.actions .btn-primary[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/devices/components/add-zone-dialog/add-zone-dialog.component.ts
+++ b/devices/components/add-zone-dialog/add-zone-dialog.component.ts
@@ -1,0 +1,112 @@
+import { Component, inject } from '@angular/core';
+import {
+  FormBuilder,
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { DynamicDialogRef, DynamicDialogConfig } from 'primeng/dynamicdialog';
+import { InputTextModule } from 'primeng/inputtext';
+import { ButtonModule } from 'primeng/button';
+import { finalize, take } from 'rxjs';
+import { DevicesStore } from '../../store/devices.store';
+
+interface AddZoneForm {
+  zoneType: FormControl<string | null>;
+  locationId: FormControl<number | null>;
+  name: FormControl<string>;
+}
+
+@Component({
+  selector: 'app-add-zone-dialog',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, InputTextModule, ButtonModule],
+  templateUrl: './add-zone-dialog.component.html',
+  styleUrl: './add-zone-dialog.component.scss',
+})
+export class AddZoneDialogComponent {
+  private readonly fb = inject(FormBuilder);
+  private readonly dialogRef = inject(DynamicDialogRef);
+  private readonly dialogConfig = inject(DynamicDialogConfig);
+  private readonly devicesStore = inject(DevicesStore);
+
+  public readonly zoneForm: FormGroup<AddZoneForm> = this.fb.group<AddZoneForm>({
+    zoneType: this.fb.control<string | null>(null, { validators: [Validators.required] }),
+    locationId: this.fb.control<number | null>(null, { validators: [Validators.required] }),
+    name: this.fb.control('', {
+      validators: [Validators.required, Validators.minLength(3)],
+      nonNullable: true,
+    }),
+  });
+
+  public isSubmitting = false;
+
+  public readonly zoneTypes =
+    this.dialogConfig.data?.zoneTypes ?? ([
+      { label: 'Entrada', value: 'ENTRY_AREA' },
+      { label: 'Plataforma de pesado', value: 'WEIGHING_PLATFORM' },
+      { label: 'Tolva', value: 'HOPPER' },
+    ] as const);
+
+  public get locationOptions() {
+    const fromDialog = this.dialogConfig.data?.locations;
+    if (fromDialog && fromDialog.length > 0) {
+      return fromDialog;
+    }
+
+    return this.devicesStore._locations().map(location => ({
+      id: location.id,
+      name: location.name,
+    }));
+  }
+
+  public submit(): void {
+    if (this.zoneForm.invalid) {
+      console.warn('Formulario inválido para crear zona', this.zoneForm.value);
+      this.zoneForm.markAllAsTouched();
+      return;
+    }
+
+    const { zoneType, locationId, name } = this.zoneForm.getRawValue();
+
+    if (!zoneType || locationId === null || !name) {
+      console.warn('Valores incompletos para crear zona', this.zoneForm.value);
+      return;
+    }
+
+    const payload = {
+      zoneType,
+      locationId,
+      name,
+    };
+
+    console.log('Enviando creación de zona desde el diálogo', payload);
+
+    this.isSubmitting = true;
+
+    this.devicesStore
+      .createZone(zoneType, locationId, name)
+      .pipe(
+        take(1),
+        finalize(() => {
+          this.isSubmitting = false;
+        })
+      )
+      .subscribe({
+        next: zone => {
+          console.log('Zona creada correctamente en el diálogo', zone);
+          this.dialogRef.close(zone);
+        },
+        error: error => {
+          console.error('Error al crear la zona', error);
+        },
+      });
+  }
+
+  public cancel(): void {
+    console.log('Cancelando creación de zona');
+    this.dialogRef.close();
+  }
+}

--- a/devices/services/zones.service.ts
+++ b/devices/services/zones.service.ts
@@ -1,0 +1,46 @@
+import { inject, Injectable } from '@angular/core';
+import { HttpClient, HttpResponse } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
+import { delay } from 'rxjs/operators';
+
+export interface CreateZonePayload {
+  zoneType: string;
+  locationId: number;
+  name: string;
+}
+
+export interface CreateZoneResponse {
+  id: number;
+  zoneType: string;
+  name: string;
+  locationId: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ZonesService {
+  private readonly http = inject(HttpClient);
+
+  /*
+  createZone(payload: CreateZonePayload): Observable<HttpResponse<CreateZoneResponse>> {
+    const url = `${environment.API_URL}/admin/locations/${payload.locationId}/zones`;
+    return this.http.post<CreateZoneResponse>(url, payload, { observe: 'response' });
+  }
+  */
+
+  // Endpoint fake
+  createZone(payload: CreateZonePayload): Observable<HttpResponse<CreateZoneResponse>> {
+    console.log('ZonesService.createZone payload (fake service):', payload);
+
+    const mockResponse: CreateZoneResponse = {
+      id: Math.floor(Math.random() * 10000) + 100,
+      zoneType: payload.zoneType,
+      name: payload.name,
+      locationId: payload.locationId,
+    };
+
+    return of({
+      status: 201,
+      body: mockResponse,
+    } as HttpResponse<CreateZoneResponse>).pipe(delay(500));
+  }
+}

--- a/devices/store/devices.store.ts
+++ b/devices/store/devices.store.ts
@@ -8,7 +8,7 @@ import {
   withState,
 } from '@ngrx/signals';
 import { rxMethod } from '@ngrx/signals/rxjs-interop';
-import { tap, switchMap } from 'rxjs';
+import { map, tap, switchMap } from 'rxjs';
 import { devicesSliceInitialValue } from './devices.slice';
 import { DevicesService } from '../services/devices.service';
 import { setBusyUpdater } from './updaters/set-busy.updater';
@@ -20,11 +20,15 @@ import { setDevicesFiltersUpdater } from './updaters/set-devices-filters.updater
 import { changeCurrentPageUpdater } from './updaters/change-current-page.updater';
 import { toggleFiltersUpdater } from './updaters/toggle-filters.updater';
 import { DevicesResponse } from '../models/device.model';
+import { Zone } from '../models/device.model';
+import { addZoneToLocationUpdater } from './updaters/add-zone-to-location.updater';
+import { ZonesService, CreateZonePayload } from '../services/zones.service';
 
 export const DevicesStore = signalStore(
   withState(devicesSliceInitialValue),
   withProps(() => ({
     _devicesService: inject(DevicesService),
+    _zonesService: inject(ZonesService),
   })),
   withComputed(store => ({
     devicesTree: computed(() => devicesTreeGenerator(store._locations())),
@@ -50,6 +54,15 @@ export const DevicesStore = signalStore(
     );
 
     _fetchDevices(store.filters);
+
+    const mapResponseToZone = (
+      responseBody: { id: number; name: string; zoneType: string }
+    ): Zone => ({
+      id: Number(responseBody.id),
+      name: responseBody.name,
+      type: responseBody.zoneType,
+      devices: [],
+    });
 
     return {
       reloadDevices: () => {
@@ -77,6 +90,35 @@ export const DevicesStore = signalStore(
       },
       toggleFiltersOpen: (isOpen?: boolean) => {
         patchState(store, toggleFiltersUpdater(isOpen));
+      },
+      createZone: (zoneType: string, locationId: number, name: string) => {
+        const payload: CreateZonePayload = {
+          zoneType,
+          locationId,
+          name,
+        };
+
+        console.log('Request createZone payload:', payload);
+
+        return store._zonesService.createZone(payload).pipe(
+          tap(response => {
+            console.log('Response from createZone:', response);
+            if (response.status === 201) {
+              console.log('201 Created');
+            }
+          }),
+          map(response => {
+            if (response.status !== 201 || !response.body) {
+              throw new Error(`Create zone failed with status ${response.status}`);
+            }
+
+            const zone = mapResponseToZone(response.body);
+            console.log('área añadida');
+            patchState(store, addZoneToLocationUpdater(locationId, zone));
+
+            return zone;
+          })
+        );
       },
     };
   })

--- a/devices/store/updaters/add-zone-to-location.updater.ts
+++ b/devices/store/updaters/add-zone-to-location.updater.ts
@@ -1,0 +1,19 @@
+import { PartialStateUpdater } from '@ngrx/signals';
+import { DevicesSlice } from '../devices.slice';
+import { Zone } from '../../models/device.model';
+
+export function addZoneToLocationUpdater(
+  locationId: number,
+  zone: Zone
+): PartialStateUpdater<DevicesSlice> {
+  return state => ({
+    _locations: state._locations.map(location =>
+      location.id === locationId
+        ? {
+            ...location,
+            zones: [...location.zones, zone],
+          }
+        : location
+    ),
+  });
+}


### PR DESCRIPTION
## Summary
- inject the zones service into the devices store and expose a createZone helper that logs, calls the API and patches locations when the response is 201
- add an updater to append zones to a location and scaffold a zones service with a fake implementation for now
- migrate the add-zone dialog to use the devices store, keeping form validation, logs, and the submit/loading handling tied to the store response

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc95e2a6588327b49d7638500b2e99